### PR TITLE
Update remediate-teams-chat.ps1

### DIFF
--- a/Remove Teams Chat/remediate-teams-chat.ps1
+++ b/Remove Teams Chat/remediate-teams-chat.ps1
@@ -17,7 +17,7 @@ Context: 64 Bit
 $MSTeams = "MicrosoftTeams"
 
 $WinPackage = Get-AppxPackage -allusers | Where-Object {$_.Name -eq $MSTeams}
-$ProvisionedPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $WinPackage }
+$ProvisionedPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $WinPackage.Name }
 If ($null -ne $WinPackage) 
 {
     Remove-AppxPackage  -Package $WinPackage.PackageFullName


### PR DESCRIPTION
Change line 20 to include .Name for $WinPackage.  I found that $ProvisionedPackage was not getting populated if it was just left to $WinPackage