### PR TITLE
Add New Script: Device Auto-Syncer

### DIFF
--- a/Device Auto-Syncer/AutoSyncDetect.ps1
+++ b/Device Auto-Syncer/AutoSyncDetect.ps1
@@ -1,0 +1,18 @@
+# Create variable for the time of the last Intune sync.
+$PushInfo = Get-ScheduledTask -TaskName PushLaunch | Get-ScheduledTaskInfo
+$LastPush = $PushInfo.LastRunTime
+$CurrentTime=(GET-DATE)
+
+# Calculate the time difference between the current date/time and the date stored in the variable.
+$TimeDiff = New-TimeSpan -Start $LastPush -End $CurrentTime
+
+# If/Else statement checking whether the Time Difference between the Last Sync and the current time is less or greater than 2 days
+if ($TimeDiff.Days -gt 2) {
+    # The time difference is more than 2 days
+    Write-Host "Last Sync was more than 2 days ago"
+    Exit 1
+} else {
+    # The time difference is less than 2 days
+    Write-Host "Sync Complete"
+    Exit 0
+}

--- a/Device Auto-Syncer/AutoSyncRemediate.ps1
+++ b/Device Auto-Syncer/AutoSyncRemediate.ps1
@@ -1,0 +1,8 @@
+try {
+    Get-ScheduledTask | ? {$_.TaskName -eq 'PushLaunch'} | Start-ScheduledTask
+    Exit 0
+}
+catch {
+    Write-Error $_
+    Exit 1
+}


### PR DESCRIPTION
This detection script checks if a device's last sync with Intune was over 2 days ago and if so performs a sync via the 'PushLaunch' command. Obviously customisable to any amount of days you'd like to choose.