### PR TITLE
Script to remove consumer apps

### DIFF
--- a/Remove-ConsumerApps/README.md
+++ b/Remove-ConsumerApps/README.md
@@ -1,0 +1,25 @@
+# Remove Consumer Apps
+
+This script removes apps for all users by a given list of app names and app package names. It also removes the provisioned packages for new users.
+
+## Usage/Examples
+
+In **Remove-ConsumerAppsDetection.ps1** and **Remove-ConsumerAppsRemediation.ps1** change the list of apps to remove:
+
+```powershell
+$ConsumerApps = @{
+    "Microsoft.XboxApp"                      = "Xbox App"
+    "Microsoft.XboxGameOverlay"              = "Xbox Game Overlay"
+    "Microsoft.Xbox.TCUI"                    = "Xbox TCUI"
+    "Microsoft.MicrosoftSolitaireCollection" = "Solitaire Collection"
+    "Microsoft.549981C3F5F10"                = "Cortana"
+    "Vendor.Appname"                         = "My Custom App Name"
+}
+```
+
+Import it a dectection script, make sure:
+
+- Run this script using the logged-on credentials = No
+- Run script in 64-bit PowerShell = Yes
+
+Schedule it to run repeatedly, e.g. once

--- a/Remove-ConsumerApps/Remove-ConsumerAppsDetection.ps1
+++ b/Remove-ConsumerApps/Remove-ConsumerAppsDetection.ps1
@@ -1,0 +1,35 @@
+<#
+Version: 1.0
+Author: 
+- Marius Wyss (marius.wyss@microsoft.com)
+Script: Remove-ConsumerAppsDetection.ps1
+Description:
+Hint: This is a community script. There is no guarantee for this. Please check thoroughly before running.
+Version 1.0: Init
+Run as: System
+Context: 64 Bit
+#> 
+
+$ConsumerApps = @{
+    "Microsoft.XboxApp" = "Xbox App"
+    "Microsoft.XboxGameOverlay" = "Xbox Game Overlay"
+    "Microsoft.Xbox.TCUI" = "Xbox TCUI"
+    "Microsoft.MicrosoftSolitaireCollection" = "Solitaire Collection"
+    "Microsoft.549981C3F5F10" = "Cortana"
+}
+
+# Check if any of the Consumer Apps are installed
+$UninstallPackages = $ConsumerApps.Keys
+
+$InstalledPackages = Get-AppxPackage -AllUsers | Where { ($UninstallPackages -contains $_.Name) }
+
+If ($InstalledPackages -eq $null) {
+    Write-Output "No Consumer Apps installed"
+    Exit 0
+}
+
+If ($InstalledPackages -ne $null) {
+    $out = "Consumer Apps installed: ({0})" -f $($($ConsumerApps[$InstalledPackages.Name]) -join ', ')
+    Write-Output $out
+    Exit 1
+}

--- a/Remove-ConsumerApps/Remove-ConsumerAppsRemediation.ps1
+++ b/Remove-ConsumerApps/Remove-ConsumerAppsRemediation.ps1
@@ -1,0 +1,52 @@
+<#
+Version: 1.0
+Author: 
+- Marius Wyss (marius.wyss@microsoft.com)
+Script: Remove-ConsumerAppsRemediation.ps1
+Description:
+Hint: This is a community script. There is no guarantee for this. Please check thoroughly before running.
+Version 1.0: Init
+Run as: System
+Context: 64 Bit
+#> 
+
+$ConsumerApps = @{
+    "Microsoft.XboxApp"                      = "Xbox App"
+    "Microsoft.XboxGameOverlay"              = "Xbox Game Overlay"
+    "Microsoft.Xbox.TCUI"                    = "Xbox TCUI"
+    "Microsoft.MicrosoftSolitaireCollection" = "Solitaire Collection"
+    "Microsoft.549981C3F5F10"                = "Cortana"
+}
+
+
+# Uninstall all Consumer Apps
+# Check if any of the Consumer Apps are installed
+$UninstallPackages = $ConsumerApps.Keys
+
+$InstalledPackages = Get-AppxPackage -AllUsers | Where { ($UninstallPackages -contains $_.Name) }
+
+
+$out = @()
+foreach ($App in $InstalledPackages) {
+    try {
+        Get-AppxPackage -Name $($App.Name) -AllUsers | Remove-AppxPackage -AllUsers | Out-Null
+        $AllAppXProvisionedPackage | Where { $_.DisplayName -eq $($App.Name) } |  Remove-AppxProvisionedPackage -Online | Out-Null
+        $out += $App.Name
+    }
+    catch {
+        $errMsg = $_.Exception.Message
+        return $errMsg
+        Exit 1
+    }
+}
+
+if ($out.Count -eq 0) {
+    Write-Output "No Consumer Apps found"
+    Exit 0
+}
+
+if ($out.Count -gt 0) {
+    Write-Output "Consumer Apps removed: ($($out -join ', '))"
+    Exit 0
+}
+


### PR DESCRIPTION
This script removes apps for all users by a given list of app names and app package names. It also removes the provisioned packages for new users.

**See  Remove-ConsumerApps/README.md for more details.**