### PR TITLE
Variable renamed

### DIFF
--- a/Add-Winget-App/detect-app.ps1
+++ b/Add-Winget-App/detect-app.ps1
@@ -13,7 +13,7 @@ Run as: System
 Context: 64 Bit
 #> 
 
-$appnid = ""
+$appid = ""
 
 $ResolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe"
 if ($ResolveWingetPath){


### PR DESCRIPTION
The original variable name was incorrect in the declaration.  I renamed the variable to match the name used throughout the rest of the script.