### PR TITLE
Update remediate-automatictimezone.ps1

### DIFF
--- a/AutomaticTimezone/remediate-automatictimezone.ps1
+++ b/AutomaticTimezone/remediate-automatictimezone.ps1
@@ -21,7 +21,8 @@ $regvalue = "Allow"
 $regvalue2 = "3"
 
 ##Enter the type of the registry key for example DWord
-$regtype = "DWORD"
+$regtype = "STRING"
+$regtype2 = "DWORD"
 
 
 New-ItemProperty -LiteralPath $regpath -Name $regname -Value $regvalue -PropertyType $regtype -Force -ea SilentlyContinue;


### PR DESCRIPTION
The Allow value is a string and not a DWORD.
The initial script is not working so I propose this change that fixes it.