### PR TITLE
security: harden randomness, remove Invoke-Expression, enforce HTTPS

### DIFF
--- a/Create-LocalAdmin/remediation_Create-LocalAdminLAPSRemediation.ps1
+++ b/Create-LocalAdmin/remediation_Create-LocalAdminLAPSRemediation.ps1
@@ -15,7 +15,29 @@ Context: 64 Bit
 #> 
 
 $localAdminName = ""
-$password = -join ((65..90) + (97..122) + (48..57) + (35..38) + (40..47) | Get-Random -Count 35 | ForEach-Object {[char]$_}) | ConvertTo-SecureString -AsPlainText -Force
+
+# Generate the password using a cryptographically secure RNG. Get-Random on Windows
+# PowerShell 5.1 (the default on Intune-managed endpoints) is backed by System.Random,
+# which is NOT cryptographically secure and is predictable. RNGCryptoServiceProvider
+# (or RandomNumberGenerator on .NET Core) provides unbiased, unpredictable bytes.
+$charSet = [char[]](((65..90) + (97..122) + (48..57) + (35..38) + (40..47)) | ForEach-Object { [char]$_ })
+$length = 35
+$rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+try {
+    $bytes = New-Object byte[] ($length * 4)
+    $rng.GetBytes($bytes)
+    $chars = for ($i = 0; $i -lt $length; $i++) {
+        # Use a 32-bit unsigned value and modulo into the charset. Bias is negligible for
+        # this charset size relative to UInt32.MaxValue.
+        $val = [BitConverter]::ToUInt32($bytes, $i * 4)
+        $charSet[$val % $charSet.Length]
+    }
+    $password = (-join $chars) | ConvertTo-SecureString -AsPlainText -Force
+}
+finally {
+    $rng.Dispose()
+}
+
 $Localadmingroupname = $((Get-LocalGroup -SID "S-1-5-32-544").Name)
 
 New-LocalUser "$localAdminName" -Password $password -FullName "$localAdminName" -Description "LAPS account"

--- a/Make-Speedtest/remediation_Run-SpeedttestRemediation.ps1
+++ b/Make-Speedtest/remediation_Run-SpeedttestRemediation.ps1
@@ -38,7 +38,8 @@ Function Measure-NetworkSpeed($f_testFile, $f_fileSize){
 }
 
 Function Get-PublicIp{
-    return (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
+    # Use HTTPS to prevent tampering of the returned public IP by an on-path attacker.
+    return (Invoke-WebRequest -Uri "https://ifconfig.me/ip" -UseBasicParsing).Content
 }
 
 Function Build-Signature ($customerId, $sharedKey, $date, $contentLength, $method, $contentType, $resource)

--- a/Profile-Backup/remediation_remediate-backup.ps1
+++ b/Profile-Backup/remediation_remediate-backup.ps1
@@ -49,9 +49,8 @@ Invoke-WebRequest -Uri $launchurl -OutFile $launchscript -UseBasicParsing
 }
 
 ##Run it
-$acommand = "C:\Windows\System32\Cscript.exe $DirectoryToCreate\run-invisible.vbs"
-
-Invoke-Expression $acommand
+# Use Start-Process with explicit arguments to avoid Invoke-Expression / string-based command execution
+Start-Process -FilePath "$env:WINDIR\System32\Cscript.exe" -ArgumentList "`"$DirectoryToCreate\run-invisible.vbs`"" -WindowStyle Hidden
 
 ##Create/Update txt for detection
 $todaysdate = Get-Date -Format "dd-MM-yyyy-HH"

--- a/Rotate-LocalAdminPassword/remediation_rotate-localadminpassword.ps1
+++ b/Rotate-LocalAdminPassword/remediation_rotate-localadminpassword.ps1
@@ -16,9 +16,51 @@ try {
         exit 1
     }
 
-    Add-Type -AssemblyName System.Web
-    $NewPassword = [System.Web.Security.Membership]::GeneratePassword(24, 6)
-    $SecurePassword = ConvertTo-SecureString $NewPassword -AsPlainText -Force
+    # [System.Web.Security.Membership]::GeneratePassword is known to produce biased
+    # output (and is unavailable on PowerShell 7 without System.Web). Use a CSPRNG
+    # over an explicit, well-defined character set instead.
+    $upper   = [char[]](65..90)
+    $lower   = [char[]](97..122)
+    $digits  = [char[]](48..57)
+    $special = [char[]]'!@#$%^&*()-_=+[]{}'
+    $charSet = $upper + $lower + $digits + $special
+    $length  = 24
+
+    function Get-SecureRandomUInt32 {
+        param([System.Security.Cryptography.RandomNumberGenerator]$Rng)
+        $b = New-Object byte[] 4
+        $Rng.GetBytes($b)
+        return [BitConverter]::ToUInt32($b, 0)
+    }
+
+    $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+    try {
+        # Guarantee complexity: one char from each class.
+        $required = @(
+            $upper[   (Get-SecureRandomUInt32 -Rng $rng) % $upper.Length   ],
+            $lower[   (Get-SecureRandomUInt32 -Rng $rng) % $lower.Length   ],
+            $digits[  (Get-SecureRandomUInt32 -Rng $rng) % $digits.Length  ],
+            $special[ (Get-SecureRandomUInt32 -Rng $rng) % $special.Length ]
+        )
+
+        $fill = for ($i = 0; $i -lt ($length - $required.Count); $i++) {
+            $charSet[ (Get-SecureRandomUInt32 -Rng $rng) % $charSet.Length ]
+        }
+
+        $all = @($required) + @($fill)
+
+        # Fisher-Yates shuffle using CSPRNG indices.
+        for ($i = $all.Count - 1; $i -gt 0; $i--) {
+            $j = (Get-SecureRandomUInt32 -Rng $rng) % ($i + 1)
+            $tmp = $all[$i]; $all[$i] = $all[$j]; $all[$j] = $tmp
+        }
+
+        $NewPassword = -join $all
+        $SecurePassword = ConvertTo-SecureString $NewPassword -AsPlainText -Force
+    }
+    finally {
+        $rng.Dispose()
+    }
 
     $AdminAccount | Set-LocalUser -Password $SecurePassword -ErrorAction Stop
     Write-Output "Local administrator password has been rotated successfully"

--- a/Test-LAPSUser/remediation_new-LAPSUser.ps1
+++ b/Test-LAPSUser/remediation_new-LAPSUser.ps1
@@ -56,7 +56,23 @@ function New-RandomPassword {
 			[string] $RegEx = '[\w\$\%\&\/\(\)\=\?\!\\,\.\-_\:;\]\+\*\~<>\|]'
 	)
 
-	[string] $password = -join ( [char[]](0..127) -match $RegEx | Get-Random -Count $length )
+	# Use a cryptographically secure RNG. Get-Random on Windows PowerShell 5.1 is backed
+	# by System.Random, which is predictable and unsuitable for generating credentials
+	# (especially for a LAPS-style local administrator account).
+	[char[]]$allowed = [char[]](0..127) -match $RegEx
+	$rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+	try {
+		$bytes = New-Object byte[] ($Length * 4)
+		$rng.GetBytes($bytes)
+		$chars = for ($i = 0; $i -lt $Length; $i++) {
+			$val = [BitConverter]::ToUInt32($bytes, $i * 4)
+			$allowed[$val % $allowed.Length]
+		}
+		[string]$password = -join $chars
+	}
+	finally {
+		$rng.Dispose()
+	}
 	return $password
 }
 


### PR DESCRIPTION
## Summary

This PR addresses several real security issues across the remediation scripts:

- **Profile-Backup/remediation_remediate-backup.ps1:54** - Replaced `Invoke-Expression $acommand` with `Start-Process -FilePath ... -ArgumentList ...`. The original code built a command string and executed it dynamically; while the inputs are local, `Invoke-Expression` is unnecessary here and is a well-known anti-pattern that makes future regressions (e.g. introducing user-controlled paths into `$DirectoryToCreate`) silently exploitable.
- **Make-Speedtest/remediation_Run-SpeedttestRemediation.ps1:41** - Changed `Invoke-WebRequest -uri "http://ifconfig.me/ip"` to `https://ifconfig.me/ip`. The previous HTTP call lets any on-path attacker tamper with the returned public IP that is then forwarded to Log Analytics, polluting telemetry and masking the real device location.
- **Create-LocalAdmin/remediation_Create-LocalAdminLAPSRemediation.ps1:18** - Replaced `Get-Random` with `RNGCryptoServiceProvider`. `Get-Random` in Windows PowerShell 5.1 (which is the default on Intune-managed Windows endpoints) is backed by `System.Random` and is **not** cryptographically secure. Using it to mint a local administrator password produces predictable secrets that can be recovered from a known seed / timing.
- **Test-LAPSUser/remediation_new-LAPSUser.ps1:59** - Same `Get-Random` issue as above; replaced with `RNGCryptoServiceProvider`-backed generation in `New-RandomPassword`.
- **Rotate-LocalAdminPassword/remediation_rotate-localadminpassword.ps1:20** - Replaced `[System.Web.Security.Membership]::GeneratePassword(24, 6)` with a CSPRNG-based generator that guarantees one character from each class (upper / lower / digit / special) and Fisher-Yates shuffles using CSPRNG indices. The legacy `Membership` API is known to produce biased output and is unavailable on PowerShell 7 without loading `System.Web`.

## Test plan

- [ ] On Windows PowerShell 5.1 and PowerShell 7, run `Create-LocalAdminLAPSRemediation.ps1` after setting `$localAdminName` and confirm a new user is created with a 35-character password.
- [ ] On Windows PowerShell 5.1, run `Rotate-LocalAdminPassword/remediation_rotate-localadminpassword.ps1` and verify it completes successfully and the built-in administrator password is rotated.
- [ ] Run `Profile-Backup/remediation_remediate-backup.ps1` and verify the backup files are downloaded and the VBS launcher is executed (Cscript.exe spawned, `backup.txt` created).
- [ ] Run `Make-Speedtest/remediation_Run-SpeedttestRemediation.ps1` with valid Log Analytics credentials and confirm the speed test still completes and the public IP is reported correctly.
- [ ] Sample several generated passwords from each script and confirm they include characters from each class and contain no obvious bias.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)