### PR TITLE
Security: verify downloaded remediation tools

### DIFF
--- a/Profile-cleanup/remediation_remediate-old-profiles.ps1
+++ b/Profile-cleanup/remediation_remediate-old-profiles.ps1
@@ -12,6 +12,28 @@ Version 1.0: Init
 Run as: System
 Context: 64 Bit
 #> 
+
+function Save-VerifiedDownload {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSha256
+    )
+
+    Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing -ErrorAction Stop
+    $actualHash = (Get-FileHash -Path $OutFile -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($actualHash -ne $ExpectedSha256.ToLowerInvariant()) {
+        Remove-Item -Path $OutFile -Force -ErrorAction SilentlyContinue
+        throw "Hash validation failed for $OutFile. Expected $ExpectedSha256, got $actualHash."
+    }
+}
+
 $days = 30
 $profiles = (get-CimInstance win32_userprofile | Where-Object {$_.LastUseTime -lt $(Get-Date).Date.AddDays(-$days)})
 $profilecount = $profiles.Count
@@ -22,13 +44,13 @@ $tempdir = $env:TEMP
 ##Comment out whichever version you don't want to use
 
 ##Download DelProf1
-Invoke-WebRequest -URI "https://github.com/andrew-s-taylor/public/raw/main/delprof/delprof.exe" -OutFile "$tempdir\delprof.exe"
+Save-VerifiedDownload -Uri "https://github.com/andrew-s-taylor/public/raw/main/delprof/delprof.exe" -OutFile "$tempdir\delprof.exe" -ExpectedSha256 "1da35d3bc379f57de9384fef2ce8f9a29cea9f5e8a6550a5023f29f39bf327ad"
 ##Run DelProf1
 Start-Process -FilePath "$tempdir\delprof.exe" -ArgumentList /Q /D:$days
 Remove-Item "$tempdir\delprof.exe"
 
 ##Download DelProf2
-Invoke-WebRequest -URI "https://github.com/andrew-s-taylor/public/raw/main/delprof/DelProf2.exe" -OutFile "$tempdir\delprof2.exe"
+Save-VerifiedDownload -Uri "https://github.com/andrew-s-taylor/public/raw/main/delprof/DelProf2.exe" -OutFile "$tempdir\delprof2.exe" -ExpectedSha256 "b456e05c6825dea9f854e3ae37deb36e7f5f2d847fc2c7f053327559a9414ed6"
 ##Run DelProf2
 Start-Process -FilePath "$tempdir\delprof2.exe" -ArgumentList /q /d:$days
 remove-item "$tempdir\delprof2.exe"

--- a/Remove Teams Chat/remediation_remediate-teams-chat.ps1
+++ b/Remove Teams Chat/remediation_remediate-teams-chat.ps1
@@ -13,6 +13,27 @@ Run as: User
 Context: 64 Bit
 #> 
 
+function Save-VerifiedDownload {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSha256
+    )
+
+    Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing -ErrorAction Stop
+    $actualHash = (Get-FileHash -Path $OutFile -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if ($actualHash -ne $ExpectedSha256.ToLowerInvariant()) {
+        Remove-Item -Path $OutFile -Force -ErrorAction SilentlyContinue
+        throw "Hash validation failed for $OutFile. Expected $ExpectedSha256, got $actualHash."
+    }
+}
+
 #Remove Teams Chat
 $MSTeams = "MicrosoftTeams"
 
@@ -29,10 +50,11 @@ If ($null -ne $ProvisionedPackage)
 }
 
 ##Tweak reg permissions
-invoke-webrequest -uri "https://github.com/andrew-s-taylor/public/raw/main/De-Bloat/SetACL.exe" -outfile "C:\Windows\Temp\SetACL.exe"
-C:\Windows\Temp\SetACL.exe -on "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications" -ot reg -actn setowner -ownr "n:administrators"
- C:\Windows\Temp\SetACL.exe -on "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications" -ot reg -actn ace -ace "n:administrators;p:full"
-Remove-Item C:\Windows\Temp\SetACL.exe -recurse
+$setAclPath = "C:\Windows\Temp\SetACL.exe"
+Save-VerifiedDownload -Uri "https://github.com/andrew-s-taylor/public/raw/main/De-Bloat/SetACL.exe" -OutFile $setAclPath -ExpectedSha256 "4efc87b7e585fcbe4eaed656d3dbadaec88beca7f92ca7f0089583b428a6b221"
+& $setAclPath -on "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications" -ot reg -actn setowner -ownr "n:administrators"
+& $setAclPath -on "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications" -ot reg -actn ace -ace "n:administrators;p:full"
+Remove-Item -Path $setAclPath -Force
 
 
 ##Stop it coming back


### PR DESCRIPTION
## Summary
- add SHA-256 validation for downloaded DelProf and SetACL binaries
- remove downloaded binaries when hash validation fails
- call SetACL through an explicit verified path instead of direct path execution

## Verification
- pwsh parse check for updated remediation scripts
- Invoke-ScriptAnalyzer focused security rules: PSAvoidUsingInvokeExpression, PSAvoidUsingConvertToSecureStringWithPlainText, PSAvoidUsingPlainTextForPassword
- git diff --check